### PR TITLE
Switch authentication storage to UUIDs

### DIFF
--- a/src/main/java/uk/org/whoami/authme/AuthMe.java
+++ b/src/main/java/uk/org/whoami/authme/AuthMe.java
@@ -193,15 +193,17 @@ public class AuthMe extends JavaPlugin {
 
     private void onReload(Player[] players) {
         for (Player player : players) {
+            String uuid = player.getUniqueId().toString();
             String name = player.getName().toLowerCase();
             String ip = player.getAddress().getAddress().getHostAddress();
 
-            boolean authAvail = database.isAuthAvailable(name);
+            boolean authAvail = database.isAuthAvailable(uuid);
 
             if (authAvail) {
                 if (settings.isSessionsEnabled()) {
-                    PlayerAuth auth = database.getAuth(name);
-                    if (auth.getNickname().equals(name) && auth.getIp().equals(ip)) {
+                    PlayerAuth auth = database.getAuth(uuid);
+                    if (auth != null && auth.getUuid().equals(uuid) && auth.getIp().equals(ip)) {
+                        auth.setUsername(name);
                         PlayerCache.getInstance().addPlayer(auth);
                         player.sendMessage(m._("valid_session"));
                         break;
@@ -227,10 +229,10 @@ public class AuthMe extends JavaPlugin {
             int msgInterval = settings.getWarnMessageInterval();
             BukkitScheduler sched = this.getServer().getScheduler();
             if (time != 0) {
-                int id = sched.scheduleSyncDelayedTask(this, new TimeoutTask(this, name), time);
-                LimboCache.getInstance().getLimboPlayer(name).setTimeoutTaskId(id);
+                int id = sched.scheduleSyncDelayedTask(this, new TimeoutTask(this, uuid), time);
+                LimboCache.getInstance().getLimboPlayer(uuid).setTimeoutTaskId(id);
             }
-            sched.scheduleSyncDelayedTask(this, new MessageTask(this, name, msg, msgInterval));
+            sched.scheduleSyncDelayedTask(this, new MessageTask(this, uuid, msg, msgInterval));
         }
     }
 

--- a/src/main/java/uk/org/whoami/authme/AuthMe.java
+++ b/src/main/java/uk/org/whoami/authme/AuthMe.java
@@ -158,7 +158,7 @@ public class AuthMe extends JavaPlugin {
         pm.registerEvent(Event.Type.ENTITY_TARGET, entityListener,
                 Priority.Lowest, this);
 
-        this.getCommand("authme").setExecutor(new AdminCommand(database));
+        this.getCommand("authme").setExecutor(new AdminCommand(this, database));
         this.getCommand("register").setExecutor(new RegisterCommand(this, database));
         this.getCommand("login").setExecutor(new LoginCommand(database));
         this.getCommand("changepassword").setExecutor(new ChangePasswordCommand(database));

--- a/src/main/java/uk/org/whoami/authme/cache/auth/PlayerAuth.java
+++ b/src/main/java/uk/org/whoami/authme/cache/auth/PlayerAuth.java
@@ -18,24 +18,34 @@ package uk.org.whoami.authme.cache.auth;
 
 public class PlayerAuth {
 
-    private String nickname;
+    private final String uuid;
+    private String username;
     private String hash;
     private String ip;
     private long lastLogin;
 
-    public PlayerAuth(String nickname, String hash, String ip, long lastLogin) {
-        this.nickname = nickname;
+    public PlayerAuth(String uuid, String username, String hash, String ip, long lastLogin) {
+        this.uuid = uuid;
+        this.username = username;
         this.hash = hash;
         this.ip = ip;
         this.lastLogin = lastLogin;
     }
 
-    public String getIp() {
-        return ip;
+    public String getUuid() {
+        return uuid;
     }
 
-    public String getNickname() {
-        return nickname;
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getIp() {
+        return ip;
     }
 
     public String getHash() {
@@ -64,14 +74,14 @@ public class PlayerAuth {
             return false;
         }
         PlayerAuth other = (PlayerAuth) obj;
-        
-        return other.getIp().equals(this.ip) && other.getNickname().equals(this.nickname);
+
+        return other.getIp().equals(this.ip) && other.getUuid().equals(this.uuid);
     }
 
     @Override
     public int hashCode() {
         int hashCode = 7;
-        hashCode = 71 * hashCode + (this.nickname != null ? this.nickname.hashCode() : 0);
+        hashCode = 71 * hashCode + (this.uuid != null ? this.uuid.hashCode() : 0);
         hashCode = 71 * hashCode + (this.ip != null ? this.ip.hashCode() : 0);
         return hashCode;
     }

--- a/src/main/java/uk/org/whoami/authme/cache/auth/PlayerCache.java
+++ b/src/main/java/uk/org/whoami/authme/cache/auth/PlayerCache.java
@@ -28,24 +28,24 @@ public class PlayerCache {
     }
 
     public void addPlayer(PlayerAuth auth) {
-        cache.put(auth.getNickname(), auth);
+        cache.put(auth.getUuid(), auth);
     }
 
     public void updatePlayer(PlayerAuth auth) {
-        cache.remove(auth.getNickname());
-        cache.put(auth.getNickname(), auth);
+        cache.remove(auth.getUuid());
+        cache.put(auth.getUuid(), auth);
     }
 
-    public void removePlayer(String user) {
-        cache.remove(user);
+    public void removePlayer(String uuid) {
+        cache.remove(uuid);
     }
 
-    public boolean isAuthenticated(String user) {
-        return cache.containsKey(user);
+    public boolean isAuthenticated(String uuid) {
+        return cache.containsKey(uuid);
     }
 
-    public PlayerAuth getAuth(String user) {
-        return cache.get(user);
+    public PlayerAuth getAuth(String uuid) {
+        return cache.get(uuid);
     }
 
     public static PlayerCache getInstance() {

--- a/src/main/java/uk/org/whoami/authme/cache/limbo/LimboCache.java
+++ b/src/main/java/uk/org/whoami/authme/cache/limbo/LimboCache.java
@@ -32,25 +32,26 @@ public class LimboCache {
     }
 
     public void addLimboPlayer(Player player) {
+        String uuid = player.getUniqueId().toString();
         String name = player.getName().toLowerCase();
         Location loc = player.getLocation();
         ItemStack[] inv = player.getInventory().getContents();
         ItemStack[] arm = player.getInventory().getArmorContents();
         //int gameMode = player.getGameMode().getValue();
 
-        cache.put(player.getName().toLowerCase(), new LimboPlayer(name, loc, inv, arm));
+        cache.put(uuid, new LimboPlayer(uuid, name, loc, inv, arm));
     }
 
-    public void deleteLimboPlayer(String name) {
-        cache.remove(name);
+    public void deleteLimboPlayer(String uuid) {
+        cache.remove(uuid);
     }
 
-    public LimboPlayer getLimboPlayer(String name) {
-        return cache.get(name);
+    public LimboPlayer getLimboPlayer(String uuid) {
+        return cache.get(uuid);
     }
 
-    public boolean hasLimboPlayer(String name) {
-        return cache.containsKey(name);
+    public boolean hasLimboPlayer(String uuid) {
+        return cache.containsKey(uuid);
     }
 
     public static LimboCache getInstance() {

--- a/src/main/java/uk/org/whoami/authme/cache/limbo/LimboPlayer.java
+++ b/src/main/java/uk/org/whoami/authme/cache/limbo/LimboPlayer.java
@@ -21,6 +21,7 @@ import org.bukkit.inventory.ItemStack;
 
 public class LimboPlayer {
 
+    private final String uuid;
     private String name;
     private ItemStack[] inventory;
     private ItemStack[] armour;
@@ -28,12 +29,17 @@ public class LimboPlayer {
     private int timeoutTaskId = -1;
     private int gameMode = 0;
 
-    public LimboPlayer(String name, Location loc, ItemStack[] inventory, ItemStack[] armour) {
+    public LimboPlayer(String uuid, String name, Location loc, ItemStack[] inventory, ItemStack[] armour) {
+        this.uuid = uuid;
         this.name = name;
         this.loc = loc;
         this.inventory = inventory;
         this.armour = armour;
         this.gameMode = gameMode;
+    }
+
+    public String getUuid() {
+        return uuid;
     }
 
     public String getName() {

--- a/src/main/java/uk/org/whoami/authme/commands/AdminCommand.java
+++ b/src/main/java/uk/org/whoami/authme/commands/AdminCommand.java
@@ -16,6 +16,12 @@
 
 package uk.org.whoami.authme.commands;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.Date;
@@ -25,7 +31,11 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 
+import com.projectposeidon.api.PoseidonUUID;
+import com.projectposeidon.api.UUIDType;
+
 import uk.org.whoami.authme.ConsoleLogger;
+import uk.org.whoami.authme.AuthMe;
 import uk.org.whoami.authme.cache.auth.PlayerAuth;
 import uk.org.whoami.authme.cache.auth.PlayerCache;
 import uk.org.whoami.authme.datasource.DataSource;
@@ -35,18 +45,22 @@ import uk.org.whoami.authme.settings.Settings;
 
 public class AdminCommand implements CommandExecutor {
 
+    private static final String LEGACY_AUTH_FILE = Settings.PLUGIN_FOLDER + "/auths.db";
+
     private Messages m = Messages.getInstance();
     private Settings settings = Settings.getInstance();
     private DataSource database;
+    private final AuthMe plugin;
 
-    public AdminCommand(DataSource database) {
+    public AdminCommand(AuthMe plugin, DataSource database) {
+        this.plugin = plugin;
         this.database = database;
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmnd, String label, String[] args) {
         if (args.length == 0) {
-            sender.sendMessage("Usage: /authme reload|register playername password|changepassword playername password|unregister playername|purge|betaevo");
+            sender.sendMessage("Usage: /authme reload|register playername password|changepassword playername password|unregister playername|purge|betaevo|convertuuid");
             return true;
         }
 
@@ -87,6 +101,8 @@ public class AdminCommand implements CommandExecutor {
                 sender.sendMessage("BetaEVO mode enabled");
             }
             ConsoleLogger.info("BetaEVO mode " + (betaEVO ? "disabled" : "enabled") + " by " + sender.getName());
+        } else if (args[0].equalsIgnoreCase("convertuuid")) {
+            convertLegacyDatabase(sender);
         } else if (args[0].equalsIgnoreCase("register")) {
             if (args.length != 3) {
                 sender.sendMessage("Usage: /authme register playername password");
@@ -167,10 +183,126 @@ public class AdminCommand implements CommandExecutor {
 
             ConsoleLogger.info(args[1] + " unregistered");
         } else {
-            sender.sendMessage("Usage: /authme reload|register playername password|changepassword playername password|unregister playername");
+            sender.sendMessage("Usage: /authme reload|register playername password|changepassword playername password|unregister playername|purge|betaevo|convertuuid");
         }
         return true;
-}
+    }
+
+    private void convertLegacyDatabase(CommandSender sender) {
+        File legacyFile = new File(LEGACY_AUTH_FILE);
+        if (!legacyFile.exists() || !legacyFile.isFile()) {
+            sender.sendMessage("Legacy auths.db not found. No conversion performed.");
+            return;
+        }
+
+        File targetFile = new File(Settings.AUTH_FILE);
+        File parent = targetFile.getParentFile();
+        if (parent != null && !parent.exists() && !parent.mkdirs()) {
+            sender.sendMessage("Unable to create AuthMe data directory for conversion.");
+            return;
+        }
+
+        File backupFile = parent != null
+                ? new File(parent, targetFile.getName() + ".bak")
+                : new File(targetFile.getName() + ".bak");
+        boolean backedUp = false;
+        if (targetFile.exists() && targetFile.length() > 0) {
+            if (backupFile.exists() && !backupFile.delete()) {
+                sender.sendMessage("Unable to remove existing auths-uuid.db.bak backup. Aborting.");
+                return;
+            }
+            if (!targetFile.renameTo(backupFile)) {
+                sender.sendMessage("Unable to back up existing auths-uuid.db. Aborting.");
+                return;
+            }
+            backedUp = true;
+        }
+
+        int converted = 0;
+        int skipped = 0;
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(legacyFile));
+             BufferedWriter writer = new BufferedWriter(new FileWriter(targetFile, false))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.trim().isEmpty()) {
+                    continue;
+                }
+
+                String[] values = line.split(":");
+                if (values.length < 2) {
+                    skipped++;
+                    continue;
+                }
+
+                String originalName = values[0].trim();
+                if (originalName.isEmpty()) {
+                    skipped++;
+                    continue;
+                }
+
+                String username = originalName.toLowerCase();
+                String hash = values[1].trim();
+                String ip = "198.18.0.1";
+                if (values.length > 2 && !values[2].isEmpty()) {
+                    ip = values[2].trim();
+                }
+
+                long lastLogin = 0;
+                if (values.length > 3 && !values[3].isEmpty()) {
+                    try {
+                        lastLogin = Long.parseLong(values[3].trim());
+                    } catch (NumberFormatException ex) {
+                        lastLogin = 0;
+                    }
+                }
+
+                UUID uuid = resolveUuid(originalName);
+                if (uuid == null) {
+                    ConsoleLogger.info("Skipping legacy record for '" + originalName + "' because no UUID could be resolved.");
+                    skipped++;
+                    continue;
+                }
+
+                writer.write(uuid.toString() + ":" + username + ":" + hash + ":" + ip + ":" + lastLogin);
+                writer.newLine();
+                converted++;
+            }
+        } catch (IOException ex) {
+            ConsoleLogger.showError("Failed to convert legacy database: " + ex.getMessage());
+            sender.sendMessage(m._("error"));
+            return;
+        }
+
+        if (backedUp) {
+            sender.sendMessage("Existing auths-uuid.db backed up to " + backupFile.getName());
+        }
+
+        sender.sendMessage("Converted " + converted + " accounts to auths-uuid.db" + (skipped > 0 ? " (" + skipped + " skipped)" : ""));
+        if (skipped > 0) {
+            sender.sendMessage("Check console for players that were skipped due to missing UUIDs.");
+        }
+    }
+
+    private UUID resolveUuid(String username) {
+        if (plugin != null && plugin.isRunningPoseidon()) {
+            try {
+                UUIDType uuidType = PoseidonUUID.getPlayerUUIDCacheStatus(username);
+                if (uuidType == UUIDType.UNKNOWN) {
+                    return null;
+                } else if (uuidType == UUIDType.OFFLINE) {
+                    return PoseidonUUID.getPlayerOfflineUUID(username);
+                } else {
+                    return PoseidonUUID.getPlayerMojangUUID(username);
+                }
+            } catch (Exception ex) {
+                ConsoleLogger.showError("Unable to resolve UUID for '" + username + "': " + ex.getMessage());
+                return null;
+            }
+        }
+
+        return UUID.nameUUIDFromBytes(("OfflinePlayer:" + username).getBytes(StandardCharsets.UTF_8));
+    }
 
     private String getOfflineUuid(String playerName) {
         return UUID.nameUUIDFromBytes(("OfflinePlayer:" + playerName).getBytes(StandardCharsets.UTF_8)).toString();

--- a/src/main/java/uk/org/whoami/authme/commands/ChangePasswordCommand.java
+++ b/src/main/java/uk/org/whoami/authme/commands/ChangePasswordCommand.java
@@ -53,10 +53,11 @@ public class ChangePasswordCommand implements CommandExecutor {
         }
 
         Player player = (Player) sender;
+        String uuid = player.getUniqueId().toString();
         String name = player.getName().toLowerCase();
         String ip = player.getAddress().getAddress().getHostAddress();
 
-        if (!PlayerCache.getInstance().isAuthenticated(name)) {
+        if (!PlayerCache.getInstance().isAuthenticated(uuid)) {
             player.sendMessage(m._("not_logged_in"));
             return true;
         }
@@ -69,9 +70,10 @@ public class ChangePasswordCommand implements CommandExecutor {
         try {
             String hashnew = PasswordSecurity.getHash(settings.getPasswordHash(), args[1]);
 
-            if (PasswordSecurity.comparePasswordWithHash(args[0], PlayerCache.getInstance().getAuth(name).getHash())) {
-                PlayerAuth auth = PlayerCache.getInstance().getAuth(name);
+            if (PasswordSecurity.comparePasswordWithHash(args[0], PlayerCache.getInstance().getAuth(uuid).getHash())) {
+                PlayerAuth auth = PlayerCache.getInstance().getAuth(uuid);
                 auth.setHash(hashnew);
+                auth.setUsername(name);
                 if (!database.updatePassword(auth)) {
                     player.sendMessage(m._("error"));
                     return true;

--- a/src/main/java/uk/org/whoami/authme/commands/LogoutCommand.java
+++ b/src/main/java/uk/org/whoami/authme/commands/LogoutCommand.java
@@ -58,19 +58,23 @@ public class LogoutCommand implements CommandExecutor {
         }
 
         Player player = (Player) sender;
+        String uuid = player.getUniqueId().toString();
         String name = player.getName().toLowerCase();
 
-        if (!PlayerCache.getInstance().isAuthenticated(name)) {
+        if (!PlayerCache.getInstance().isAuthenticated(uuid)) {
             player.sendMessage(m._("not_logged_in"));
             return true;
         }
 
         //clear session
-        PlayerAuth auth = PlayerCache.getInstance().getAuth(name);
-        auth.setIp("198.18.0.1");
-        database.updateSession(auth);
+        PlayerAuth auth = PlayerCache.getInstance().getAuth(uuid);
+        if (auth != null) {
+            auth.setUsername(name);
+            auth.setIp("198.18.0.1");
+            database.updateSession(auth);
+        }
 
-        PlayerCache.getInstance().removePlayer(name);
+        PlayerCache.getInstance().removePlayer(uuid);
 
         LimboCache.getInstance().addLimboPlayer(player);
         player.getInventory().setArmorContents(new ItemStack[0]);
@@ -83,10 +87,10 @@ public class LogoutCommand implements CommandExecutor {
         int interval = settings.getWarnMessageInterval();
         BukkitScheduler sched = sender.getServer().getScheduler();
         if (delay != 0) {
-            int id = sched.scheduleSyncDelayedTask(plugin, new TimeoutTask(plugin, name), delay);
-            LimboCache.getInstance().getLimboPlayer(name).setTimeoutTaskId(id);
+            int id = sched.scheduleSyncDelayedTask(plugin, new TimeoutTask(plugin, uuid), delay);
+            LimboCache.getInstance().getLimboPlayer(uuid).setTimeoutTaskId(id);
         }
-        sched.scheduleSyncDelayedTask(plugin, new MessageTask(plugin, name, m._("login_msg"), interval));
+        sched.scheduleSyncDelayedTask(plugin, new MessageTask(plugin, uuid, m._("login_msg"), interval));
 
         player.sendMessage(m._("logout"));
         ConsoleLogger.info(player.getDisplayName() + " logged out");

--- a/src/main/java/uk/org/whoami/authme/commands/RegisterCommand.java
+++ b/src/main/java/uk/org/whoami/authme/commands/RegisterCommand.java
@@ -61,10 +61,11 @@ public class RegisterCommand implements CommandExecutor {
         }
 
         Player player = (Player) sender;
+        String uuid = player.getUniqueId().toString();
         String name = player.getName().toLowerCase();
         String ip = player.getAddress().getAddress().getHostAddress();
 
-        if (PlayerCache.getInstance().isAuthenticated(name)) {
+        if (PlayerCache.getInstance().isAuthenticated(uuid)) {
             player.sendMessage(m._("logged_in"));
             return true;
         }
@@ -79,7 +80,7 @@ public class RegisterCommand implements CommandExecutor {
             return true;
         }
 
-        if (database.isAuthAvailable(player.getName().toLowerCase())) {
+        if (database.isAuthAvailable(uuid)) {
             player.sendMessage(m._("user_regged"));
             return true;
         }
@@ -95,14 +96,14 @@ public class RegisterCommand implements CommandExecutor {
         try {
             String hash = PasswordSecurity.getHash(settings.getPasswordHash(), args[0]);
 
-            PlayerAuth auth = new PlayerAuth(name, hash, ip, new Date().getTime());
+            PlayerAuth auth = new PlayerAuth(uuid, name, hash, ip, new Date().getTime());
             if (!database.saveAuth(auth)) {
                 player.sendMessage(m._("error"));
                 return true;
             }
             PlayerCache.getInstance().addPlayer(auth);
 
-            LimboPlayer limbo = LimboCache.getInstance().getLimboPlayer(name);
+            LimboPlayer limbo = LimboCache.getInstance().getLimboPlayer(uuid);
             if (limbo != null) {
                 player.getInventory().setContents(limbo.getInventory());
                 player.getInventory().setArmorContents(limbo.getArmour());
@@ -111,7 +112,7 @@ public class RegisterCommand implements CommandExecutor {
                 }
 
                 sender.getServer().getScheduler().cancelTask(limbo.getTimeoutTaskId());
-                LimboCache.getInstance().deleteLimboPlayer(name);
+                LimboCache.getInstance().deleteLimboPlayer(uuid);
             }
 
             player.sendMessage(m._("registered"));

--- a/src/main/java/uk/org/whoami/authme/commands/UnregisterCommand.java
+++ b/src/main/java/uk/org/whoami/authme/commands/UnregisterCommand.java
@@ -60,9 +60,10 @@ public class UnregisterCommand implements CommandExecutor {
         }
 
         Player player = (Player) sender;
+        String uuid = player.getUniqueId().toString();
         String name = player.getName().toLowerCase();
 
-        if (!PlayerCache.getInstance().isAuthenticated(name)) {
+        if (!PlayerCache.getInstance().isAuthenticated(uuid)) {
             player.sendMessage(m._("not_logged_in"));
             return true;
         }
@@ -76,7 +77,7 @@ public class UnregisterCommand implements CommandExecutor {
             //Check if their password is correct
             try {
                 //If password is incorrect prevent change
-                if (!PasswordSecurity.comparePasswordWithHash(args[0], PlayerCache.getInstance().getAuth(name).getHash())) {
+                if (!PasswordSecurity.comparePasswordWithHash(args[0], PlayerCache.getInstance().getAuth(uuid).getHash())) {
                     player.sendMessage(m._("wrong_pwd"));
                     return true;
                 }
@@ -90,11 +91,11 @@ public class UnregisterCommand implements CommandExecutor {
             ConsoleLogger.info(player.getName() + " Has authenticated an unregister using Beta Evolutions");
         }
 
-        if (!database.removeAuth(name)) {
+        if (!database.removeAuth(uuid)) {
             player.sendMessage("error");
             return true;
         }
-        PlayerCache.getInstance().removePlayer(player.getName().toLowerCase());
+        PlayerCache.getInstance().removePlayer(uuid);
         LimboCache.getInstance().addLimboPlayer(player);
         player.getInventory().setArmorContents(new ItemStack[0]);
         player.getInventory().setContents(new ItemStack[36]);
@@ -103,10 +104,10 @@ public class UnregisterCommand implements CommandExecutor {
         int interval = settings.getWarnMessageInterval();
         BukkitScheduler sched = sender.getServer().getScheduler();
         if (delay != 0) {
-            int id = sched.scheduleSyncDelayedTask(plugin, new TimeoutTask(plugin, name), delay);
-            LimboCache.getInstance().getLimboPlayer(name).setTimeoutTaskId(id);
+            int id = sched.scheduleSyncDelayedTask(plugin, new TimeoutTask(plugin, uuid), delay);
+            LimboCache.getInstance().getLimboPlayer(uuid).setTimeoutTaskId(id);
         }
-        sched.scheduleSyncDelayedTask(plugin, new MessageTask(plugin, name, m._("reg_msg"), interval));
+        sched.scheduleSyncDelayedTask(plugin, new MessageTask(plugin, uuid, m._("reg_msg"), interval));
 
         player.sendMessage("unregistered");
         ConsoleLogger.info(player.getDisplayName() + " unregistered himself");

--- a/src/main/java/uk/org/whoami/authme/datasource/DataSource.java
+++ b/src/main/java/uk/org/whoami/authme/datasource/DataSource.java
@@ -25,9 +25,9 @@ public interface DataSource {
         MYSQL, FILE
     }
 
-    boolean isAuthAvailable(String user);
+    boolean isAuthAvailable(String uuid);
 
-    PlayerAuth getAuth(String user);
+    PlayerAuth getAuth(String uuid);
 
     boolean saveAuth(PlayerAuth auth);
 
@@ -37,7 +37,7 @@ public interface DataSource {
 
     int purgeDatabase(long until);
 
-    boolean removeAuth(String user);
+    boolean removeAuth(String uuid);
 
     void close();
 

--- a/src/main/java/uk/org/whoami/authme/listener/AuthMeBlockListener.java
+++ b/src/main/java/uk/org/whoami/authme/listener/AuthMeBlockListener.java
@@ -42,17 +42,17 @@ public class AuthMeBlockListener extends BlockListener {
         }
 
         Player player = event.getPlayer();
-        String name = player.getName().toLowerCase();
+        String uuid = player.getUniqueId().toString();
 
         if(CitizensCommunicator.isNPC(player)) {
             return;
         }
 
-        if (PlayerCache.getInstance().isAuthenticated(name)) {
+        if (PlayerCache.getInstance().isAuthenticated(uuid)) {
             return;
         }
 
-        if (!data.isAuthAvailable(name)) {
+        if (!data.isAuthAvailable(uuid)) {
             if (!settings.isForcedRegistrationEnabled()) {
                 return;
             }
@@ -68,17 +68,17 @@ public class AuthMeBlockListener extends BlockListener {
         }
 
         Player player = event.getPlayer();
-        String name = player.getName().toLowerCase();
+        String uuid = player.getUniqueId().toString();
 
         if(CitizensCommunicator.isNPC(player)) {
             return;
         }
 
-        if (PlayerCache.getInstance().isAuthenticated(player.getName().toLowerCase())) {
+        if (PlayerCache.getInstance().isAuthenticated(uuid)) {
             return;
         }
 
-        if (!data.isAuthAvailable(name)) {
+        if (!data.isAuthAvailable(uuid)) {
             if (!settings.isForcedRegistrationEnabled()) {
                 return;
             }

--- a/src/main/java/uk/org/whoami/authme/listener/AuthMeChat.java
+++ b/src/main/java/uk/org/whoami/authme/listener/AuthMeChat.java
@@ -12,7 +12,7 @@ public class AuthMeChat extends PlayerListener {
             return;
         }
         //HOTFIX - Start
-        if (PlayerCache.getInstance().isAuthenticated(event.getPlayer().getName().toLowerCase())) {
+        if (PlayerCache.getInstance().isAuthenticated(event.getPlayer().getUniqueId().toString())) {
             return;
         }
         event.setCancelled(true);

--- a/src/main/java/uk/org/whoami/authme/listener/AuthMeEntityListener.java
+++ b/src/main/java/uk/org/whoami/authme/listener/AuthMeEntityListener.java
@@ -51,13 +51,13 @@ public class AuthMeEntityListener extends EntityListener {
         }
 
         Player player = (Player) entity;
-        String name = player.getName().toLowerCase();
+        String uuid = player.getUniqueId().toString();
 
-        if (PlayerCache.getInstance().isAuthenticated(name)) {
+        if (PlayerCache.getInstance().isAuthenticated(uuid)) {
             return;
         }
 
-        if (!data.isAuthAvailable(name)) {
+        if (!data.isAuthAvailable(uuid)) {
             if (!settings.isForcedRegistrationEnabled()) {
                 return;
             }
@@ -78,13 +78,13 @@ public class AuthMeEntityListener extends EntityListener {
         }
 
         Player player = (Player) entity;
-        String name = player.getName().toLowerCase();
+        String uuid = player.getUniqueId().toString();
 
-        if (PlayerCache.getInstance().isAuthenticated(name)) {
+        if (PlayerCache.getInstance().isAuthenticated(uuid)) {
             return;
         }
 
-        if (!data.isAuthAvailable(name)) {
+        if (!data.isAuthAvailable(uuid)) {
             if (!settings.isForcedRegistrationEnabled()) {
                 return;
             }

--- a/src/main/java/uk/org/whoami/authme/settings/Settings.java
+++ b/src/main/java/uk/org/whoami/authme/settings/Settings.java
@@ -29,7 +29,7 @@ public final class Settings extends Configuration {
 
     public static final String PLUGIN_FOLDER = "./plugins/AuthMe";
     public static final String CACHE_FOLDER = Settings.PLUGIN_FOLDER + "/cache";
-    public static final String AUTH_FILE = Settings.PLUGIN_FOLDER + "/auths.db";
+    public static final String AUTH_FILE = Settings.PLUGIN_FOLDER + "/auths-uuid.db";
     public static final String MESSAGE_FILE = Settings.PLUGIN_FOLDER + "/messages.yml";
     public static final String SETTINGS_FILE = Settings.PLUGIN_FOLDER + "/config.yml";
     private static Settings singleton;
@@ -68,7 +68,8 @@ public final class Settings extends Configuration {
         getMySQLPassword();
         getMySQLDatabase();
         getMySQLTablename();
-        getMySQLColumnName();
+        getMySQLColumnUuid();
+        getMySQLColumnUsername();
         getMySQLColumnPassword();
         getMySQLColumnIp();
         getMySQLColumnLastLogin();
@@ -290,8 +291,21 @@ public final class Settings extends Configuration {
         return getString(key);
     }
 
-    public String getMySQLColumnName() {
-        String key = "DataSource.mySQLColumnName";
+    public String getMySQLColumnUuid() {
+        String key = "DataSource.mySQLColumnUuid";
+        if (getString(key) == null) {
+            String legacyKey = "DataSource.mySQLColumnName";
+            if (getString(legacyKey) != null) {
+                setProperty(key, getString(legacyKey));
+            } else {
+                setProperty(key, "uuid");
+            }
+        }
+        return getString(key);
+    }
+
+    public String getMySQLColumnUsername() {
+        String key = "DataSource.mySQLColumnUsername";
         if (getString(key) == null) {
             setProperty(key, "username");
         }

--- a/src/main/java/uk/org/whoami/authme/task/MessageTask.java
+++ b/src/main/java/uk/org/whoami/authme/task/MessageTask.java
@@ -24,26 +24,26 @@ import uk.org.whoami.authme.cache.auth.PlayerCache;
 
 public class MessageTask implements Runnable {
 
-    private JavaPlugin plugin;
-    private String name;
-    private String msg;
-    private int interval;
+    private final JavaPlugin plugin;
+    private final String uuid;
+    private final String msg;
+    private final int interval;
 
-    public MessageTask(JavaPlugin plugin, String name, String msg, int interval) {
+    public MessageTask(JavaPlugin plugin, String uuid, String msg, int interval) {
         this.plugin = plugin;
-        this.name = name;
+        this.uuid = uuid;
         this.msg = msg;
         this.interval = interval;
     }
 
     @Override
     public void run() {
-        if (PlayerCache.getInstance().isAuthenticated(name)) {
+        if (PlayerCache.getInstance().isAuthenticated(uuid)) {
             return;
         }
 
         for (Player player : plugin.getServer().getOnlinePlayers()) {
-            if (player.getName().toLowerCase().equals(name)) {
+            if (player.getUniqueId().toString().equals(uuid)) {
                 player.sendMessage(msg);
 
                 BukkitScheduler sched = plugin.getServer().getScheduler();

--- a/src/main/java/uk/org/whoami/authme/task/TimeoutTask.java
+++ b/src/main/java/uk/org/whoami/authme/task/TimeoutTask.java
@@ -26,33 +26,29 @@ import uk.org.whoami.authme.settings.Messages;
 
 public class TimeoutTask implements Runnable {
 
-    private JavaPlugin plugin;
-    private String name;
-    private Messages m = Messages.getInstance();
+    private final JavaPlugin plugin;
+    private final String uuid;
+    private final Messages m = Messages.getInstance();
 
-    public TimeoutTask(JavaPlugin plugin, String name) {
+    public TimeoutTask(JavaPlugin plugin, String uuid) {
         this.plugin = plugin;
-        this.name = name;
-    }
-
-    public String getName() {
-        return name;
+        this.uuid = uuid;
     }
 
     @Override
     public void run() {
-        if (PlayerCache.getInstance().isAuthenticated(name)) {
+        if (PlayerCache.getInstance().isAuthenticated(uuid)) {
             return;
         }
 
         for (Player player : plugin.getServer().getOnlinePlayers()) {
-            if (player.getName().toLowerCase().equals(name)) {
-                if (LimboCache.getInstance().hasLimboPlayer(name)) {
-                    LimboPlayer inv = LimboCache.getInstance().getLimboPlayer(name);
+            if (player.getUniqueId().toString().equals(uuid)) {
+                if (LimboCache.getInstance().hasLimboPlayer(uuid)) {
+                    LimboPlayer inv = LimboCache.getInstance().getLimboPlayer(uuid);
                     player.getInventory().setArmorContents(inv.getArmour());
                     player.getInventory().setContents(inv.getInventory());
                     player.teleport(inv.getLoc());
-                    LimboCache.getInstance().deleteLimboPlayer(name);
+                    LimboCache.getInstance().deleteLimboPlayer(uuid);
                 }
                 player.kickPlayer(m._("timeout"));
                 break;


### PR DESCRIPTION
## Summary
- convert player authentication models and caches to track players by UUID instead of usernames
- update file and MySQL data sources, including configuration defaults, to store UUIDs alongside usernames
- adjust commands, listeners, and scheduled tasks to pass UUIDs through the authentication flow and preserve limbo/session state

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68da921726e48329a6d98aa63e6523a0